### PR TITLE
[Feature] add stat soft clipped per allele and mq per allele

### DIFF
--- a/include/graphtyper/graph/haplotype.hpp
+++ b/include/graphtyper/graph/haplotype.hpp
@@ -74,7 +74,12 @@ public:
   void clipped_reads_to_stats(bool const fully_aligned);
   void graph_complexity_to_stats();
   void mapq_to_stats(uint8_t const mapq);
-  void realignment_to_stats(bool const is_unaligned_read, uint32_t const original_pos, uint32_t const new_pos);
+  void realignment_to_stats(bool const is_unaligned_read,
+                            bool const is_originally_clipped,
+                            uint32_t const original_pos,
+                            uint32_t const new_pos
+    );
+
   void strand_to_stats(bool const forward_strand, bool const is_first_in_pair);
   void coverage_to_gts(std::size_t const pn_index);
   std::bitset<MAX_NUMBER_OF_HAPLOTYPES> explain_to_path_explain();

--- a/include/graphtyper/typer/genotype_paths.hpp
+++ b/include/graphtyper/typer/genotype_paths.hpp
@@ -26,6 +26,7 @@ public:
   bool is_first_in_pair = true;
   bool forward_strand = true;
   bool is_originally_unaligned = false;
+  bool is_originally_clipped = false;
 
   /****************
    * CONSTRUCTORS *

--- a/include/graphtyper/typer/var_stats.hpp
+++ b/include/graphtyper/typer/var_stats.hpp
@@ -16,6 +16,8 @@ public:
   uint64_t mapq_root_total = 0u;
   uint32_t mapq_count = 0u;
   uint32_t mapq_zero_count = 0u;
+  std::vector<uint64_t> mapq_allele_root_total;
+  std::vector<uint32_t> mapq_allele_counts;
 
   /** Clipped reads */
   uint32_t clipped_reads = 0u;
@@ -24,6 +26,7 @@ public:
   uint32_t unaligned_reads = 0u;
   std::vector<uint32_t> realignment_distance;
   std::vector<uint32_t> realignment_count;
+  std::vector<uint32_t> originally_clipped;
 
   /** Strand bias per allele */
   std::vector<uint32_t> r1_strand_forward;
@@ -42,13 +45,14 @@ public:
   /**
    * MODIFIERS
    */
-  void add_mapq(uint8_t const new_mapq);
+  void add_mapq(uint8_t allele_id, uint8_t const new_mapq);
   void add_realignment_distance(uint8_t const allele_id, uint32_t const original_pos, uint32_t const new_pos);
 
   /**
    * CLASS INFORMATION
    */
   uint8_t get_rms_mapq() const;
+  std::string get_rms_mapq_per_allele() const;
   std::string get_realignment_count() const;
   std::string get_realignment_distance() const;
   std::string get_forward_strand_bias() const;
@@ -62,7 +66,7 @@ public:
   std::string get_r2_reverse_strand_bias() const;
 };
 
-std::string join_strand_bias(std::vector<uint32_t> const & bias);
+template<class T> std::string join_strand_bias(std::vector<T> const & bias);
 std::string join_strand_bias(std::vector<uint32_t> const & r1bias, std::vector<uint32_t> const & r2bias);
 std::vector<std::string> split_bias_to_strings(std::string const & bias);
 std::vector<uint32_t> split_bias_to_numbers(std::string const & bias);

--- a/include/graphtyper/typer/var_stats.hpp
+++ b/include/graphtyper/typer/var_stats.hpp
@@ -21,12 +21,12 @@ public:
 
   /** Clipped reads */
   uint32_t clipped_reads = 0u;
+  std::vector<uint32_t> originally_clipped;
 
   /** Realignment statistics */
   uint32_t unaligned_reads = 0u;
   std::vector<uint32_t> realignment_distance;
   std::vector<uint32_t> realignment_count;
-  std::vector<uint32_t> originally_clipped;
 
   /** Strand bias per allele */
   std::vector<uint32_t> r1_strand_forward;
@@ -53,6 +53,7 @@ public:
    */
   uint8_t get_rms_mapq() const;
   std::string get_rms_mapq_per_allele() const;
+  std::string get_originally_clipped_reads() const;
   std::string get_realignment_count() const;
   std::string get_realignment_distance() const;
   std::string get_forward_strand_bias() const;

--- a/include/graphtyper/typer/variant.hpp
+++ b/include/graphtyper/typer/variant.hpp
@@ -53,7 +53,10 @@ public:
   bool is_indel() const;
   bool is_with_matching_first_bases() const;
   uint64_t get_seq_depth() const;
+  uint64_t get_seq_depth_of_allele(uint16_t const allele_id) const;
+  std::vector<uint64_t> get_seq_depth_of_all_alleles() const;
   uint64_t get_rooted_mapq() const;
+  std::vector<uint64_t> get_rooted_mapq_per_allele() const;
   uint64_t get_qual() const; // Gets quality of record
 
 

--- a/src/graph/haplotype.cpp
+++ b/src/graph/haplotype.cpp
@@ -217,7 +217,7 @@ Haplotype::clipped_reads_to_stats(bool const fully_aligned)
 void
 Haplotype::graph_complexity_to_stats()
 {
-  assert (var_stats.size() == gts.size());
+  assert(var_stats.size() == gts.size());
 
   for (std::size_t i = 0; i < gts.size(); ++i)
     var_stats[i].graph_complexity = graph.get_10log10_num_paths(gts[i].first_variant_node);
@@ -227,23 +227,27 @@ Haplotype::graph_complexity_to_stats()
 void
 Haplotype::mapq_to_stats(uint8_t const new_mapq)
 {
-  assert (var_stats.size() == gts.size());
-  assert (var_stats.size() == coverage.size());
+  assert(var_stats.size() == gts.size());
+  assert(var_stats.size() == coverage.size());
 
   for (std::size_t i = 0; i < var_stats.size(); ++i)
   {
     // coverage[i] == 0xFFFFu means there is no coverage
     if (coverage[i] != 0xFFFFu && coverage[i] != 0xFFFEu)
-      var_stats[i].add_mapq(new_mapq);
+      var_stats[i].add_mapq(coverage[i], new_mapq);
   }
 }
 
 
 void
-Haplotype::realignment_to_stats(bool const is_unaligned_read, uint32_t const original_pos, uint32_t const new_pos)
+Haplotype::realignment_to_stats(bool const is_unaligned_read,
+                                bool const is_originally_clipped,
+                                uint32_t const original_pos,
+                                uint32_t const new_pos
+  )
 {
-  assert (var_stats.size() == gts.size());
-  assert (var_stats.size() == coverage.size());
+  assert(var_stats.size() == gts.size());
+  assert(var_stats.size() == coverage.size());
 
   if (is_unaligned_read)
   {
@@ -257,7 +261,14 @@ Haplotype::realignment_to_stats(bool const is_unaligned_read, uint32_t const ori
     for (std::size_t i = 0; i < var_stats.size(); ++i)
     {
       if (coverage[i] != 0xFFFFu && coverage[i] != 0xFFFEu)
+      {
+        assert(coverage[i] < var_stats[i].originally_clipped.size());
+
+        if (is_originally_clipped)
+          ++var_stats[i].originally_clipped[coverage[i]];
+
         var_stats[i].add_realignment_distance(coverage[i] /*allele_id*/, original_pos, new_pos);
+      }
     }
   }
 }
@@ -266,8 +277,8 @@ Haplotype::realignment_to_stats(bool const is_unaligned_read, uint32_t const ori
 void
 Haplotype::strand_to_stats(bool const forward_strand, bool const is_first_in_pair)
 {
-  assert (var_stats.size() == gts.size());
-  assert (var_stats.size() == coverage.size());
+  assert(var_stats.size() == gts.size());
+  assert(var_stats.size() == coverage.size());
 
   for (std::size_t i = 0; i < var_stats.size(); ++i)
   {

--- a/src/typer/alignment.cpp
+++ b/src/typer/alignment.cpp
@@ -20,6 +20,16 @@
 namespace
 {
 
+bool
+is_clipped(seqan::String<seqan::CigarElement<> > const & cigar)
+{
+  return seqan::length(cigar) == 0 ||
+    seqan::front(cigar).operation == 'S' ||
+    seqan::front(cigar).operation == 'H' ||
+    seqan::back(cigar).operation == 'S' ||
+    seqan::back(cigar).operation == 'H';
+}
+
 void
 merge_index_queries(seqan::IupacString const & read,
                     gyper::GenotypePaths & geno,
@@ -155,6 +165,7 @@ align_unpaired_read_pairs(TReads & reads, std::vector<GenotypePaths> & genos)
       geno1.is_first_in_pair = seqan::hasFlagFirst(read_it->first);
       geno1.is_originally_unaligned = seqan::hasFlagUnmapped(read_it->first);
       geno1.original_pos = read_it->first.beginPos + 1; // Change to 1-based system
+      geno1.is_originally_clipped = is_clipped(read_it->first.cigar);
       genos.push_back(std::move(geno1));
       break;
 
@@ -163,6 +174,7 @@ align_unpaired_read_pairs(TReads & reads, std::vector<GenotypePaths> & genos)
       geno2.is_first_in_pair = seqan::hasFlagFirst(read_it->first);
       geno2.is_originally_unaligned = seqan::hasFlagUnmapped(read_it->first);
       geno2.original_pos = read_it->first.beginPos + 1; // Change to 1-based system
+      geno2.is_originally_clipped = is_clipped(read_it->first.cigar);
       genos.push_back(std::move(geno2));
       break;
     }
@@ -343,6 +355,8 @@ get_best_genotype_paths(std::vector<TReadPair> const & records)
       genos1.second.forward_strand = false; // The second read in the pair has been reverse complemented
       genos1.first.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->first);
       genos1.second.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->second);
+      genos1.first.is_originally_clipped = is_clipped(record_it->first.cigar);
+      genos1.second.is_originally_clipped = is_clipped(record_it->second.cigar);
       genos1.second.is_first_in_pair = false;
       genos1.first.original_pos = record_it->first.beginPos + 1;
       genos1.second.original_pos = record_it->second.beginPos + 1;
@@ -353,6 +367,8 @@ get_best_genotype_paths(std::vector<TReadPair> const & records)
       genos2.first.forward_strand = false; // The first read in the pair has been reverse complemented
       genos2.first.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->first);
       genos2.second.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->second);
+      genos2.first.is_originally_clipped = is_clipped(record_it->first.cigar);
+      genos2.second.is_originally_clipped = is_clipped(record_it->second.cigar);
       genos2.second.is_first_in_pair = false;
       genos2.first.original_pos = record_it->first.beginPos + 1;
       genos2.second.original_pos = record_it->second.beginPos + 1;

--- a/src/typer/alignment.cpp
+++ b/src/typer/alignment.cpp
@@ -165,7 +165,7 @@ align_unpaired_read_pairs(TReads & reads, std::vector<GenotypePaths> & genos)
       geno1.is_first_in_pair = seqan::hasFlagFirst(read_it->first);
       geno1.is_originally_unaligned = seqan::hasFlagUnmapped(read_it->first);
       geno1.original_pos = read_it->first.beginPos + 1; // Change to 1-based system
-      geno1.is_originally_clipped = is_clipped(read_it->first.cigar);
+      geno1.is_originally_clipped = seqan::hasFlagUnmapped(read_it->first) || is_clipped(read_it->first.cigar);
       genos.push_back(std::move(geno1));
       break;
 
@@ -174,7 +174,7 @@ align_unpaired_read_pairs(TReads & reads, std::vector<GenotypePaths> & genos)
       geno2.is_first_in_pair = seqan::hasFlagFirst(read_it->first);
       geno2.is_originally_unaligned = seqan::hasFlagUnmapped(read_it->first);
       geno2.original_pos = read_it->first.beginPos + 1; // Change to 1-based system
-      geno2.is_originally_clipped = is_clipped(read_it->first.cigar);
+      geno2.is_originally_clipped = seqan::hasFlagUnmapped(read_it->first) || is_clipped(read_it->first.cigar);
       genos.push_back(std::move(geno2));
       break;
     }
@@ -355,8 +355,8 @@ get_best_genotype_paths(std::vector<TReadPair> const & records)
       genos1.second.forward_strand = false; // The second read in the pair has been reverse complemented
       genos1.first.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->first);
       genos1.second.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->second);
-      genos1.first.is_originally_clipped = is_clipped(record_it->first.cigar);
-      genos1.second.is_originally_clipped = is_clipped(record_it->second.cigar);
+      genos1.first.is_originally_clipped = seqan::hasFlagUnmapped(record_it->first) || is_clipped(record_it->first.cigar);
+      genos1.second.is_originally_clipped = seqan::hasFlagUnmapped(record_it->second) || is_clipped(record_it->second.cigar);
       genos1.second.is_first_in_pair = false;
       genos1.first.original_pos = record_it->first.beginPos + 1;
       genos1.second.original_pos = record_it->second.beginPos + 1;
@@ -367,8 +367,8 @@ get_best_genotype_paths(std::vector<TReadPair> const & records)
       genos2.first.forward_strand = false; // The first read in the pair has been reverse complemented
       genos2.first.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->first);
       genos2.second.is_originally_unaligned = seqan::hasFlagUnmapped(record_it->second);
-      genos2.first.is_originally_clipped = is_clipped(record_it->first.cigar);
-      genos2.second.is_originally_clipped = is_clipped(record_it->second.cigar);
+      genos2.first.is_originally_clipped = seqan::hasFlagUnmapped(record_it->first) || is_clipped(record_it->first.cigar);
+      genos2.second.is_originally_clipped = seqan::hasFlagUnmapped(record_it->second) || is_clipped(record_it->second.cigar);
       genos2.second.is_first_in_pair = false;
       genos2.first.original_pos = record_it->first.beginPos + 1;
       genos2.second.original_pos = record_it->second.beginPos + 1;

--- a/src/typer/genotype_paths.cpp
+++ b/src/typer/genotype_paths.cpp
@@ -710,7 +710,7 @@ GenotypePaths::check_no_variant_is_missing() const
 
     if (expected_orders.size() != path.var_order.size())
     {
-      BOOST_LOG_TRIVIAL(debug) << "[genotype_paths] The number of expected orders did not match, got " << path.var_order.size() << " but expected " << expected_orders.size();
+      BOOST_LOG_TRIVIAL(error) << "[genotype_paths] The number of expected orders did not match, got " << path.var_order.size() << " but expected " << expected_orders.size();
       return false;
     }
 
@@ -727,7 +727,7 @@ GenotypePaths::check_no_variant_is_missing() const
 
     if (!all_orders_match(expected_orders, path.var_order) || !all_orders_match(path.var_order, expected_orders))
     {
-      BOOST_LOG_TRIVIAL(debug) << "[genotype_paths] Orders did not match with the expected orders.";
+      BOOST_LOG_TRIVIAL(error) << "[genotype_paths] Orders did not match with the expected orders.";
       return false;
     }
   }

--- a/src/typer/var_stats.cpp
+++ b/src/typer/var_stats.cpp
@@ -22,9 +22,9 @@ namespace gyper
 VarStats::VarStats(uint16_t allele_count) noexcept
   : mapq_allele_root_total(allele_count)
   , mapq_allele_counts(allele_count)
+  , originally_clipped(allele_count)
   , realignment_distance(allele_count)
   , realignment_count(allele_count)
-  , originally_clipped(allele_count)
   , r1_strand_forward(allele_count)
   , r1_strand_reverse(allele_count)
   , r2_strand_forward(allele_count)

--- a/src/typer/var_stats.cpp
+++ b/src/typer/var_stats.cpp
@@ -5,7 +5,7 @@
 #include <map> // std::map<Key, Value>
 #include <numeric> // std::accumulate
 #include <string> // std::string
-#include <sstream> // std::stringstream
+#include <sstream> // std::ostringstream
 #include <vector> // std::vector
 
 #include <boost/algorithm/string/split.hpp> // boost::split
@@ -105,6 +105,13 @@ VarStats::get_rms_mapq_per_allele() const
 
 
 std::string
+VarStats::get_originally_clipped_reads() const
+{
+  return join_strand_bias(this->originally_clipped);
+}
+
+
+std::string
 VarStats::get_realignment_count() const
 {
   return join_strand_bias(realignment_count); // TODO: Rename join_strand_bias()
@@ -136,7 +143,7 @@ VarStats::get_reverse_strand_bias() const
 std::string
 VarStats::get_unaligned_count() const
 {
-  std::stringstream ss;
+  std::ostringstream ss;
   ss << this->unaligned_reads;
   return ss.str();
 }

--- a/src/typer/var_stats.cpp
+++ b/src/typer/var_stats.cpp
@@ -20,8 +20,11 @@ namespace gyper
 {
 
 VarStats::VarStats(uint16_t allele_count) noexcept
-  : realignment_distance(allele_count)
+  : mapq_allele_root_total(allele_count)
+  , mapq_allele_counts(allele_count)
+  , realignment_distance(allele_count)
   , realignment_count(allele_count)
+  , originally_clipped(allele_count)
   , r1_strand_forward(allele_count)
   , r1_strand_reverse(allele_count)
   , r2_strand_forward(allele_count)
@@ -30,7 +33,7 @@ VarStats::VarStats(uint16_t allele_count) noexcept
 
 
 void
-VarStats::add_mapq(uint8_t const new_mapq)
+VarStats::add_mapq(uint8_t allele_id, uint8_t const new_mapq)
 {
   // Ignore MapQ == 255, that means MapQ is unavailable
   if (new_mapq < 255u)
@@ -40,7 +43,14 @@ VarStats::add_mapq(uint8_t const new_mapq)
     if (new_mapq == 0u)
       ++mapq_zero_count;
     else
-      mapq_root_total += static_cast<uint64_t>(new_mapq) * static_cast<uint64_t>(new_mapq); // Mapping quality rooted
+      mapq_root_total += static_cast<uint64_t>(new_mapq) * static_cast<uint64_t>(new_mapq); // Mapping quality squared
+
+    // Per allele stats
+    assert(allele_id < mapq_allele_counts.size());
+    assert(allele_id < mapq_allele_root_total.size());
+
+    ++mapq_allele_counts[allele_id];
+    mapq_allele_root_total[allele_id] += static_cast<uint64_t>(new_mapq) * static_cast<uint64_t>(new_mapq);
   }
 }
 
@@ -72,6 +82,27 @@ VarStats::get_rms_mapq() const
   else
     return 255u;
 }
+
+
+std::string
+VarStats::get_rms_mapq_per_allele() const
+{
+  std::vector<uint64_t> rms_mapq_per_allele(mapq_allele_counts.size(), 255u);
+
+  for (std::size_t i = 0; i < rms_mapq_per_allele.size(); ++i)
+  {
+    if (mapq_allele_counts[i] > 0)
+    {
+      rms_mapq_per_allele[i] =
+        static_cast<uint64_t>(
+          sqrt(static_cast<double>(mapq_allele_root_total[i]) / static_cast<double>(mapq_allele_counts[i]))
+        );
+    }
+  }
+
+  return join_strand_bias(rms_mapq_per_allele);
+}
+
 
 std::string
 VarStats::get_realignment_count() const
@@ -140,8 +171,9 @@ VarStats::get_r2_reverse_strand_bias() const
 
 
 /** Non-member functions */
+template<class T>
 std::string
-join_strand_bias(std::vector<uint32_t> const & bias)
+join_strand_bias(std::vector<T> const & bias)
 {
   if (bias.size() == 0)
     return std::string(".");
@@ -154,6 +186,10 @@ join_strand_bias(std::vector<uint32_t> const & bias)
 
   return ss.str();
 }
+
+// Explicit instantiation
+template std::string join_strand_bias(std::vector<uint32_t> const & bias);
+template std::string join_strand_bias(std::vector<uint64_t> const & bias);
 
 
 std::string

--- a/src/typer/variant.cpp
+++ b/src/typer/variant.cpp
@@ -30,6 +30,8 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
   using gyper::get_strand_bias;
   using gyper::join_strand_bias;
 
+  std::vector<uint32_t> originally_cropped = get_strand_bias(var.infos, "CRAligner");
+
   std::vector<uint32_t> mq_per_allele = get_strand_bias(var.infos, "MQperAllele");
   std::vector<uint64_t> seq_depths = var.get_seq_depth_of_all_alleles();
 
@@ -46,6 +48,8 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
 
   if (sbf.size() > 0 && sbr.size() > 0)
   {
+    std::vector<uint32_t> new_originally_cropped(new_num_seqs, 0u);
+
     std::vector<uint64_t> new_mq_rooted(new_num_seqs, 0u);
     std::vector<uint64_t> new_seq_depths(new_num_seqs, 0u);
 
@@ -74,6 +78,8 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
       assert(y < sbr1.size());
       assert(y < sbr2.size());
 
+      new_originally_cropped[new_y] += originally_cropped[y];
+
       new_mq_rooted[new_y] += mq_per_allele[y] * mq_per_allele[y] * seq_depths[y];
       new_seq_depths[new_y] += seq_depths[y];
 
@@ -90,8 +96,6 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
     }
 
     {
-      std::cerr << seq_depths[0] << "+" << seq_depths[1] << std::endl;
-      std::cerr << new_seq_depths[0] << "++" << new_seq_depths[1] << std::endl;
       std::ostringstream ss;
       std::size_t m = 0;
 
@@ -111,6 +115,8 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
       new_var.infos["MQperAllele"] = ss.str();
     }
 
+    new_var.infos["CRAligner"] = join_strand_bias(new_originally_cropped);
+
     new_var.infos["SBF"] = join_strand_bias(new_sbf);
     new_var.infos["SBR"] = join_strand_bias(new_sbr);
 
@@ -123,6 +129,7 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
     new_var.infos["RADist"] = join_strand_bias(new_ra_dist);
   }
 }
+
 
 void
 find_variant_sequences(gyper::Variant & new_var, gyper::Variant const & old_var)

--- a/src/typer/variant.cpp
+++ b/src/typer/variant.cpp
@@ -30,6 +30,9 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
   using gyper::get_strand_bias;
   using gyper::join_strand_bias;
 
+  std::vector<uint32_t> mq_per_allele = get_strand_bias(var.infos, "MQperAllele");
+  std::vector<uint64_t> seq_depths = var.get_seq_depth_of_all_alleles();
+
   std::vector<uint32_t> sbf = get_strand_bias(var.infos, "SBF");
   std::vector<uint32_t> sbr = get_strand_bias(var.infos, "SBR");
 
@@ -43,6 +46,9 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
 
   if (sbf.size() > 0 && sbr.size() > 0)
   {
+    std::vector<uint64_t> new_mq_rooted(new_num_seqs, 0u);
+    std::vector<uint64_t> new_seq_depths(new_num_seqs, 0u);
+
     std::vector<uint32_t> new_sbf(new_num_seqs, 0u);
     std::vector<uint32_t> new_sbr(new_num_seqs, 0u);
 
@@ -59,12 +65,17 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
       uint32_t new_y = old_phred_to_new_phred[y];
 
       assert(new_y < new_num_seqs);
+      assert(y < mq_per_allele.size());
+      assert(y < seq_depths.size());
       assert(y < sbf.size());
       assert(y < sbr.size());
       assert(y < sbf1.size());
       assert(y < sbf2.size());
       assert(y < sbr1.size());
       assert(y < sbr2.size());
+
+      new_mq_rooted[new_y] += mq_per_allele[y] * mq_per_allele[y] * seq_depths[y];
+      new_seq_depths[new_y] += seq_depths[y];
 
       new_sbf[new_y] += sbf[y];
       new_sbr[new_y] += sbr[y];
@@ -76,6 +87,28 @@ update_strand_bias(std::size_t const num_seqs, std::size_t new_num_seqs, std::ve
 
       new_ra_count[new_y] += ra_count[y];
       new_ra_dist[new_y] += ra_dist[y];
+    }
+
+    {
+      std::cerr << seq_depths[0] << "+" << seq_depths[1] << std::endl;
+      std::cerr << new_seq_depths[0] << "++" << new_seq_depths[1] << std::endl;
+      std::ostringstream ss;
+      std::size_t m = 0;
+
+      if (new_seq_depths[m] > 0)
+        ss << static_cast<uint16_t>(sqrt(static_cast<double>(new_mq_rooted[m]) / static_cast<double>(new_seq_depths[m])));
+      else
+        ss << 255u;
+
+      for (m = 1; m < new_num_seqs; ++m)
+      {
+        if (new_seq_depths[m] > 0)
+          ss << ',' << static_cast<uint16_t>(sqrt(static_cast<double>(new_mq_rooted[m]) / static_cast<double>(new_seq_depths[m])));
+        else
+          ss << ',' << 255u;
+      }
+
+      new_var.infos["MQperAllele"] = ss.str();
     }
 
     new_var.infos["SBF"] = join_strand_bias(new_sbf);
@@ -787,9 +820,39 @@ Variant::get_seq_depth() const
 
 
 uint64_t
+Variant::get_seq_depth_of_allele(uint16_t const allele_id) const
+{
+  uint64_t seqdepth = 0;
+
+  for (auto const & sample_call : calls)
+  {
+    assert(allele_id < sample_call.coverage.size());
+    seqdepth += sample_call.coverage[allele_id];
+  }
+
+  return seqdepth;
+}
+
+
+std::vector<uint64_t>
+Variant::get_seq_depth_of_all_alleles() const
+{
+  std::vector<uint64_t> seq_depths;
+  seq_depths.reserve(this->seqs.size());
+
+  for (std::size_t i = 0; i < this->seqs.size(); ++i)
+  {
+    seq_depths.push_back(this->get_seq_depth_of_allele(i));
+  }
+
+  return seq_depths;
+}
+
+
+uint64_t
 Variant::get_rooted_mapq() const
 {
-  uint64_t const seq_depth = get_seq_depth();
+  uint64_t const seq_depth = this->get_seq_depth();
   auto find_it = infos.find("MQ");
 
   if (find_it != infos.end())
@@ -800,6 +863,31 @@ Variant::get_rooted_mapq() const
 
   BOOST_LOG_TRIVIAL(warning) << "[graphtyper::variant] Could not extract MQ.";
   return 60ul * 60ul * seq_depth; // This is nasty, but I think this is the nicest way to go without making things so much more complicated.
+}
+
+std::vector<uint64_t>
+Variant::get_rooted_mapq_per_allele() const
+{
+  auto find_it = infos.find("MQperAllele");
+
+  if (find_it == infos.end())
+  {
+    uint64_t const seq_depth = this->get_seq_depth();
+    return std::vector<uint64_t>(this->seqs.size(), 60ul * 60ul * seq_depth);
+  }
+
+  std::vector<uint64_t> rooted_mapq_per_allele;
+  std::vector<uint32_t> mapq_per_allele = get_strand_bias(this->infos, "MQperAllele");
+  assert(mapq_per_allele.size() == seqs.size());
+  rooted_mapq_per_allele.reserve(seqs.size());
+
+  for (std::size_t i = 0; i < seqs.size(); ++i)
+  {
+    uint64_t const seq_depth = this->get_seq_depth_of_allele(i);
+    rooted_mapq_per_allele.push_back(static_cast<uint64_t>(mapq_per_allele[i] * mapq_per_allele[i]) * seq_depth);
+  }
+
+  return rooted_mapq_per_allele;
 }
 
 

--- a/src/typer/vcf.cpp
+++ b/src/typer/vcf.cpp
@@ -304,6 +304,8 @@ Vcf::read_record()
           new_var.infos["MQ"] = std::string(info_key_value.begin() + 3, info_key_value.end());
         else if (same_prefix(info_key_value, std::string("MQ0=")))
           new_var.infos["MQ0"] = std::string(info_key_value.begin() + 4, info_key_value.end());
+        else if (same_prefix(info_key_value, std::string("MQperAllele=")))
+          new_var.infos["MQperAllele"] = std::string(info_key_value.begin() + 12, info_key_value.end());
         else if (same_prefix(info_key_value, std::string("RACount=")))
           new_var.infos["RACount"] = std::string(info_key_value.begin() + 8, info_key_value.end());
         else if (same_prefix(info_key_value, std::string("RADist=")))
@@ -532,6 +534,7 @@ Vcf::write_header()
     *vcf_file << "##INFO=<ID=MaxAASR,Number=A,Type=Float,Description=\"Maximum alternative allele support ratio per alt. allele.\">\n";
     *vcf_file << "##INFO=<ID=MQ,Number=1,Type=Integer,Description=\"Root-mean-square mapping quality.\">\n";
     *vcf_file << "##INFO=<ID=MQ0,Number=1,Type=Integer,Description=\"Number of reads with MQ=0.\">\n";
+    *vcf_file << "##INFO=<ID=MQperAllele,Number=R,Type=Integer,Description=\"Mapping quality of reads aligned to each allele.\">\n";
     *vcf_file << "##INFO=<ID=QD,Number=1,Type=Float,Description=\"QUAL divided by NonReferenceSeqDepth.\">\n";
     *vcf_file << "##INFO=<ID=PS,Number=1,Type=Integer,Description=\"Unique ID of the phase set this variant is a member of. "
               << "If the calls are unphased, it is used to represent which haplotype set the variant is a member of.\">\n";
@@ -922,6 +925,7 @@ Vcf::add_haplotype(Haplotype & haplotype, bool const clear_haplotypes, uint32_t 
     new_vars[i].infos["GX"] = std::to_string(haplotype.var_stats[i].graph_complexity);
     new_vars[i].infos["MQ"] = std::to_string(haplotype.var_stats[i].get_rms_mapq());
     new_vars[i].infos["MQ0"] = std::to_string(haplotype.var_stats[i].mapq_zero_count);
+    new_vars[i].infos["MQperAllele"] = haplotype.var_stats[i].get_rms_mapq_per_allele();
     new_vars[i].infos["PS"] = std::to_string(phase_set);
     new_vars[i].infos["RACount"] = haplotype.var_stats[i].get_realignment_count();
     new_vars[i].infos["RADist"] = haplotype.var_stats[i].get_realignment_distance();

--- a/src/typer/vcf.cpp
+++ b/src/typer/vcf.cpp
@@ -296,6 +296,8 @@ Vcf::read_record()
           new_var.infos["AC"] = std::string(info_key_value.begin() + 3, info_key_value.end()); // Get AC so vcf_break_down can first remove uncalled alleles
         else if (same_prefix(info_key_value, std::string("CR=")))
           new_var.infos["CR"] = std::string(info_key_value.begin() + 3, info_key_value.end());
+        else if (same_prefix(info_key_value, std::string("CRAligner=")))
+          new_var.infos["CRAligner"] = std::string(info_key_value.begin() + 10, info_key_value.end());
         else if (same_prefix(info_key_value, std::string("GX=")))
           new_var.infos["GX"] = std::string(info_key_value.begin() + 3, info_key_value.end());
         else if (same_prefix(info_key_value, std::string("PS=")))
@@ -528,7 +530,8 @@ Vcf::write_header()
     *vcf_file << "##INFO=<ID=ABHomMulti,Number=R,Type=Float,Description=\"List of Allele Balance values for multiallelic homozygous calls (A/(A+0)) where A is the called allele and O is anything else. Each value corresponds to a ref or alt in the same order as they appear. -1 if not available.\">\n";
     *vcf_file << "##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Number of alternate alleles in called genotypes.\">\n";
     *vcf_file << "##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Number of alleles in called genotypes.\">\n";
-    *vcf_file << "##INFO=<ID=CR,Number=1,Type=Integer,Description=\"Number of clipped reads.\">\n";
+    *vcf_file << "##INFO=<ID=CR,Number=1,Type=Integer,Description=\"Number of clipped reads by Graphtyper.\">\n";
+    *vcf_file << "##INFO=<ID=CRAligner,Number=R,Type=Integer,Description=\"Number of clipped reads by the global read aligner.\">\n";
     *vcf_file << "##INFO=<ID=GX,Number=1,Type=Integer,Description=\"Graph complexity, 10*log10(#paths around the variant).\">\n";
     *vcf_file << "##INFO=<ID=MaxAAS,Number=A,Type=Integer,Description=\"Maximum alternative allele support per alt. allele.\">\n";
     *vcf_file << "##INFO=<ID=MaxAASR,Number=A,Type=Float,Description=\"Maximum alternative allele support ratio per alt. allele.\">\n";
@@ -922,6 +925,7 @@ Vcf::add_haplotype(Haplotype & haplotype, bool const clear_haplotypes, uint32_t 
   for (std::size_t i = 0; i < new_vars.size(); ++i)
   {
     new_vars[i].infos["CR"] = std::to_string(haplotype.var_stats[i].clipped_reads);
+    new_vars[i].infos["CRAligner"] = haplotype.var_stats[i].get_originally_clipped_reads();
     new_vars[i].infos["GX"] = std::to_string(haplotype.var_stats[i].graph_complexity);
     new_vars[i].infos["MQ"] = std::to_string(haplotype.var_stats[i].get_rms_mapq());
     new_vars[i].infos["MQ0"] = std::to_string(haplotype.var_stats[i].mapq_zero_count);

--- a/src/typer/vcf_operations.cpp
+++ b/src/typer/vcf_operations.cpp
@@ -236,25 +236,23 @@ vcf_merge(std::vector<std::string> vcfs, std::string const & output)
     // MQ requires the generated INFOs
     var.generate_infos();
 
-    // Add MQ and MQperAllele
+    // Add MQ
     {
-      assert (var.infos.count("SeqDepth") == 1);
-      std::string seq_depth_str = var.infos["SeqDepth"];
+      uint64_t const seq_depth = var.get_seq_depth();
 
-      if (seq_depth_str.size() > 0)
+      if (seq_depth > 0)
       {
-        uint64_t const seq_depth = std::strtoull(seq_depth_str.c_str(), NULL, 10);
-
-        if (seq_depth > 0)
-        {
-          var.infos["MQ"] = std::to_string(
-            static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_root) / static_cast<double>(seq_depth)))
-            );
-        }
+        var.infos["MQ"] = std::to_string(
+          static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_root) / static_cast<double>(seq_depth)))
+          );
+      }
+      else
+      {
+        var.infos["MQ"] = "255";
       }
     }
 
-    // Add MQperAllele
+    // MQperAllele
     if (total_mapq_per_allele.size() > 0)
     {
       std::ostringstream ss;

--- a/src/typer/vcf_operations.cpp
+++ b/src/typer/vcf_operations.cpp
@@ -1,6 +1,7 @@
 #include <cmath> // sqrt
 #include <iostream> // std::cout, std::endl
 #include <string> // std::string
+#include <sstream> // std::ostringstream
 #include <vector> // std::vector
 
 #include <boost/log/trivial.hpp> // BOOST_LOG_TRIVIAL
@@ -86,6 +87,9 @@ vcf_merge(std::vector<std::string> vcfs, std::string const & output)
       if (find_it != var.infos.end())
         mapq_zero_count = std::strtoull(find_it->second.c_str(), NULL, 10);
     }
+
+    // MQperAllele
+    std::vector<uint64_t> total_mapq_per_allele = var.get_rooted_mapq_per_allele();
 
     // SBF and SBR
     std::vector<uint32_t> strand_forward;
@@ -173,6 +177,15 @@ vcf_merge(std::vector<std::string> vcfs, std::string const & output)
           mapq_zero_count += std::strtoull(find_it->second.c_str(), NULL, 10);
       }
 
+      // Get MQperAllele
+      {
+        std::vector<uint64_t> new_mapq_per_allele = next_vcf.variants[0].get_rooted_mapq_per_allele();
+        assert(new_mapq_per_allele.size() == total_mapq_per_allele.size());
+
+        for (std::size_t m = 0; m < new_mapq_per_allele.size(); ++m)
+          total_mapq_per_allele[m] += new_mapq_per_allele[m];
+      }
+
       // Get SBF and SBR
       {
         auto add_to_bias_lambda = [&](std::string id, std::vector<uint32_t> & bias)
@@ -220,10 +233,10 @@ vcf_merge(std::vector<std::string> vcfs, std::string const & output)
     var.infos["RACount"] = join_strand_bias(realignment_count);
     var.infos["RADist"] = join_strand_bias(realignment_distance);
 
-    // MQ requirsed the generate INFOs
+    // MQ requires the generated INFOs
     var.generate_infos();
 
-    // Add MQ
+    // Add MQ and MQperAllele
     {
       assert (var.infos.count("SeqDepth") == 1);
       std::string seq_depth_str = var.infos["SeqDepth"];
@@ -233,8 +246,37 @@ vcf_merge(std::vector<std::string> vcfs, std::string const & output)
         uint64_t const seq_depth = std::strtoull(seq_depth_str.c_str(), NULL, 10);
 
         if (seq_depth > 0)
-          var.infos["MQ"] = std::to_string(static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_root) / static_cast<double>(seq_depth))));
+        {
+          var.infos["MQ"] = std::to_string(
+            static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_root) / static_cast<double>(seq_depth)))
+            );
+        }
       }
+    }
+
+    // Add MQperAllele
+    if (total_mapq_per_allele.size() > 0)
+    {
+      std::ostringstream ss;
+      std::size_t m = 0;
+      uint64_t seq_depth = var.get_seq_depth_of_allele(0);
+
+      if (seq_depth > 0)
+        ss << static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_per_allele[m]) / static_cast<double>(seq_depth)));
+      else
+        ss << 255u;
+
+      for (m = 1; m < total_mapq_per_allele.size(); ++m)
+      {
+        seq_depth = var.get_seq_depth_of_allele(m);
+
+        if (seq_depth > 0)
+          ss << ',' << static_cast<uint16_t>(sqrt(static_cast<double>(total_mapq_per_allele[m]) / static_cast<double>(seq_depth)));
+        else
+          ss << ',' << 255u;
+      }
+
+      var.infos["MQperAllele"] = ss.str();
     }
 
     // Add MQ0

--- a/src/typer/vcf_writer.cpp
+++ b/src/typer/vcf_writer.cpp
@@ -315,7 +315,7 @@ VcfWriter::update_haplotype_scores_from_path(GenotypePaths & geno, std::size_t c
     //if (not geno.is_originally_unaligned && geno.original_pos != absolute_pos.get_contig_position(geno.paths[0].start_correct_pos()).second)
     //  std::cerr << "Original pos, new pos = " << geno.original_pos << " " << absolute_pos.get_contig_position(geno.paths[0].start_correct_pos()).second << "\n";
 
-    haplotypes[*it].realignment_to_stats(geno.is_originally_unaligned, geno.original_pos /*original_pos*/, absolute_pos.get_contig_position(geno.paths[0].start_correct_pos()).second /*new_pos*/);
+    haplotypes[*it].realignment_to_stats(geno.is_originally_unaligned, geno.is_originally_clipped, geno.original_pos /*original_pos*/, absolute_pos.get_contig_position(geno.paths[0].start_correct_pos()).second /*new_pos*/);
     haplotypes[*it].graph_complexity_to_stats();
 
     haplotypes[*it].explain_to_score(pn_index, has_low_quality_snp, non_unique_paths, geno.mapq, fully_aligned, mismatches); // Update the likelihood scores

--- a/src/utilities/sam_reader.cpp
+++ b/src/utilities/sam_reader.cpp
@@ -81,7 +81,7 @@ SamReader::read_N_reads(std::size_t const N)
           {
             seqan::erase(record.seq, 0, i);
             seqan::erase(record.qual, 0, i);
-            seqan::clear(record.cigar);
+            seqan::clear(record.cigar); // Clear CIGAR as it is incorrect now
           }
 
           break;
@@ -89,7 +89,7 @@ SamReader::read_N_reads(std::size_t const N)
       }
 
       // The minimum read length is 2 overlapping k-mers
-      std::size_t const MIN_READ_LENGTH = Options::instance()->is_segment_calling ? 3 * K - 1 : 2 * K - 1;
+      std::size_t const MIN_READ_LENGTH = 2 * K - 1;
 
       // Remove Ns from back
       while (seqan::length(record.seq) >= MIN_READ_LENGTH && seqan::back(record.seq) == seqan::Iupac('N'))


### PR DESCRIPTION
The following changes start reporting the following INFO statistics in the output VCF:
 1. **CRAligner**: Number of clipped reads by the read aligner (e.g. BWA). Unaligned reads realigned to this site are also counted.
 2. **MQperAllele** Same as MQ, but specified for each allele.