### PR TITLE
[Feature] Option for writing CSI instead of TBI

### DIFF
--- a/include/graphtyper/utilities/options.hpp
+++ b/include/graphtyper/utilities/options.hpp
@@ -80,6 +80,7 @@ public:
    * CALLING OPTIONS *
    *******************/
   bool hq_reads{false};
+  bool is_csi{false};
   int sam_flag_filter{3840};
   long max_files_open{1000}; // Maximum amount of SAM/BAM/CRAM files can be opened at the same time
   long soft_cap_of_variants_in_100_bp_window{22};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,6 +680,11 @@ subcmd_genotype(paw::Parser & parser)
                         "genotype_dis_min_support_ratio",
                         "(advanced) Minimum graph discovery support ratio for a variant so it can be added to the graph.");
 
+    parser.parse_option(opts.is_csi,
+                        'C',
+                        "csi",
+                        "(advanced) If set, graphtyper will make csi indices instead of tbi.");
+
     parser.parse_option(opts.is_only_cigar_discovery,
                         ' ',
                         "is_only_cigar_discovery",
@@ -788,6 +793,11 @@ subcmd_genotype_sv(paw::Parser & parser)
   bool force_no_copy_reference{false};
 
   // Parse options
+  parser.parse_option(opts.is_csi,
+                      'C',
+                      "csi",
+                      "(advanced) If set, graphtyper will make csi indices instead of tbi.");
+
   parser.parse_option(opts.max_files_open,
                       ' ',
                       "max_files_open",

--- a/src/typer/vcf.cpp
+++ b/src/typer/vcf.cpp
@@ -1185,7 +1185,11 @@ Vcf::close_vcf_file()
 void
 Vcf::write_tbi_index() const
 {
-  int ret = tbx_index_build(filename.c_str(), 0, &tbx_conf_vcf);
+  bool const is_csi = Options::const_instance()->is_csi;
+
+  int ret = is_csi ?
+            tbx_index_build(filename.c_str(), 14, &tbx_conf_vcf) :
+            tbx_index_build(filename.c_str(), 0, &tbx_conf_vcf);
 
   if (ret < 0)
     BOOST_LOG_TRIVIAL(warning) << __HERE__ << " Could not build VCF index";

--- a/src/utilities/genotype.cpp
+++ b/src/utilities/genotype.cpp
@@ -689,6 +689,8 @@ genotype(std::string ref_path,
     }
   }
 
+  std::string const index_ext = copts.is_csi ? ".vcf.gz.csi" : ".vcf.gz.tbi";
+
   // Copy final VCFs
   auto copy_to_results =
     [&](std::string const & basename_no_ext, std::string const & extension, std::string const & id)
@@ -704,7 +706,7 @@ genotype(std::string ref_path,
 
       int ret = system(ss_cmd.str().c_str());
 
-      if (extension != ".vcf.gz.tbi" && ret != 0)
+      if (extension != index_ext && ret != 0)
       {
         BOOST_LOG_TRIVIAL(error) << __HERE__ << " This command failed '" << ss_cmd.str() << "'";
         std::exit(ret);
@@ -717,12 +719,12 @@ genotype(std::string ref_path,
     };
 
   copy_to_results("graphtyper", ".vcf.gz", ""); // Copy final VCF
-  copy_to_results("graphtyper", ".vcf.gz.tbi", ""); // Copy tabix index for final VCF
+  copy_to_results("graphtyper", index_ext, ""); // Copy tabix index for final VCF
 
   if (copts.normal_and_no_variant_overlapping)
   {
     copy_to_results("graphtyper.no_variant_overlapping", ".vcf.gz", ".no_variant_overlapping");
-    copy_to_results("graphtyper.no_variant_overlapping", ".vcf.gz.tbi", ".no_variant_overlapping");
+    copy_to_results("graphtyper.no_variant_overlapping", index_ext, ".no_variant_overlapping");
   }
 
   if (!copts.no_cleanup)

--- a/src/utilities/genotype_sv.cpp
+++ b/src/utilities/genotype_sv.cpp
@@ -34,21 +34,16 @@ genotype_sv(std::string ref_path,
 {
   // TODO: If the reference is only Ns then output an empty vcf with the sample names
   // TODO: Extract the reference sequence and use that to discover directly from BAM
-  bool constexpr is_writing_calls_vcf {
-    true
-  };
-  bool constexpr is_writing_hap {
-    false
-  };
-  bool constexpr is_discovery {
-    false
-  };
+  gyper::Options const & copts = *(Options::const_instance());
+  bool constexpr is_writing_calls_vcf{true};
+  bool constexpr is_writing_hap{false};
+  bool constexpr is_discovery{false};
 
   long const NUM_SAMPLES = sams.size();
 
   BOOST_LOG_TRIVIAL(info) << "SV genotyping region " << genomic_region.to_string();
   BOOST_LOG_TRIVIAL(info) << "Path to genome is '" << ref_path << "'";
-  BOOST_LOG_TRIVIAL(info) << "Running with up to " << Options::const_instance()->threads << " threads.";
+  BOOST_LOG_TRIVIAL(info) << "Running with up to " << copts.threads << " threads.";
   BOOST_LOG_TRIVIAL(info) << "Copying data from " << NUM_SAMPLES << " input SAM/BAM/CRAMs to local disk.";
   std::string tmp = create_temp_dir(genomic_region);
 
@@ -190,10 +185,12 @@ genotype_sv(std::string ref_path,
       }
     };
 
-  copy_vcf_to_system(""); // Copy final VCF
-  copy_vcf_to_system(".tbi"); // Copy tabix index for final VCF
+  std::string const index_ext = copts.is_csi ? ".csi" : ".tbi";
 
-  if (!Options::instance()->no_cleanup)
+  copy_vcf_to_system(""); // Copy final VCF
+  copy_vcf_to_system(index_ext); // Copy tabix index for final VCF
+
+  if (!copts.no_cleanup)
   {
     BOOST_LOG_TRIVIAL(info) << "Cleaning up temporary files.";
     remove_file_tree(tmp.c_str());


### PR DESCRIPTION
Use the --csi advanced option in the genotype and genotype_sv commands.

See more in #43  