### PR TITLE
Fix IUPAC bug

### DIFF
--- a/include/graphtyper/typer/variant.hpp
+++ b/include/graphtyper/typer/variant.hpp
@@ -98,7 +98,7 @@ std::vector<Variant> break_down_variant(Variant && variant,
 std::vector<Variant> break_down_skyr(Variant && var, long const reach);
 std::vector<Variant> extract_sequences_from_aligned_variant(Variant const && variant, std::size_t const THRESHOLD);
 std::vector<Variant> simplify_complex_haplotype(Variant && variant, std::size_t const THRESHOLD);
-std::vector<Variant> break_multi_snps(Variant const && var);
+std::vector<Variant> break_multi_snps(Variant && var);
 SampleCall bin_phred(Variant const & new_var,
                      Variant const & old_var,
                      SampleCall const & old_call,

--- a/src/typer/variant.cpp
+++ b/src/typer/variant.cpp
@@ -1044,9 +1044,6 @@ void Variant::trim_sequences(bool const keep_one_match)
 
 bool Variant::add_base_in_front(bool const add_N)
 {
-  // uint32_t abs_pos_copy = abs_pos - graph.genomic_region.get_absolute_begin_position() + 1;
-  // uint32_t abs_pos_copy = abs_pos - graph.genomic_region.get_absolute_begin_position() + 1;
-  // //graph.genomic_region.abs_pos;
   uint32_t contig_pos = absolute_pos.get_contig_position(abs_pos, graph.contigs).second;
   uint32_t contig_pos_cp = contig_pos;
   uint32_t new_contig_pos = contig_pos - 1;
@@ -1055,8 +1052,13 @@ bool Variant::add_base_in_front(bool const add_N)
   if (first_base.size() != 1 || contig_pos_cp != contig_pos || new_contig_pos != contig_pos - 1)
     return false; // The base in front could not be extracted
 
-  if (!add_N && first_base[0] == 'N')
+  bool const is_not_ACGT = first_base[0] != 'A' && first_base[0] != 'C' && first_base[0] != 'G' && first_base[0] != 'T';
+
+  if (!add_N && is_not_ACGT)
     return false;
+
+  if (add_N && is_not_ACGT)
+    first_base[0] = 'N'; // make sure it's N then
 
   // Insert the new first base in front of all the sequences
   for (auto & seq : seqs)

--- a/src/typer/variant.cpp
+++ b/src/typer/variant.cpp
@@ -1591,17 +1591,9 @@ std::vector<Variant> break_down_variant(Variant && var,
   {
     // We need to make sure there is a matching first base
     if (not var.is_with_matching_first_bases())
-    {
-      if (!var.add_base_in_front())
-      {
-        // Could not add a first base. Add N
-        for (auto & seq : var.seqs)
-          seq.insert(seq.begin(), 'N');
-      }
-    }
+      var.add_base_in_front(true); // Add N
 
     std::vector<Variant> new_broken_down_snps = break_multi_snps(std::move(var));
-
     std::move(new_broken_down_snps.begin(), new_broken_down_snps.end(), std::back_inserter(broken_down_vars));
   }
   else if (!is_no_variant_overlapping)
@@ -1623,9 +1615,9 @@ std::vector<Variant> break_down_variant(Variant && var,
     // Make everything biallelic
     std::vector<Variant> broken_down_vars2;
 
-    for (auto && var : broken_down_vars)
+    for (auto && broken_var : broken_down_vars)
     {
-      auto new_vars = make_biallelic(std::move(var));
+      auto new_vars = make_biallelic(std::move(broken_var));
       std::move(new_vars.begin(), new_vars.end(), std::back_inserter(broken_down_vars2));
     }
 
@@ -1916,12 +1908,11 @@ void find_variant_sequences(gyper::Variant & new_var, gyper::Variant const & old
   new_var.seqs = std::move(new_seqs);
 }
 
-std::vector<Variant> break_multi_snps(Variant const && var)
+std::vector<Variant> break_multi_snps(Variant && var)
 {
   uint32_t const pos = var.abs_pos;
   std::vector<std::vector<char>> const & seqs = var.seqs;
   std::vector<Variant> new_vars;
-  // assert(var.infos.count("SBF1") == 1);
 
   for (long j = 0; j < static_cast<long>(seqs[0].size()); ++j)
   {


### PR DESCRIPTION
Fixes a rare bug encountered in `graphtyper genotype`. Happens if an ambigous IUPAC base (R/W/...) occurs on the reference genome and is followed by series of SNPs are the very next base. In this case Variant::add_base_in_front() returns false and an N is added to the SNP series, but by mistake the position isn't adjusted.