### PR TITLE
Add Clang tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks: >
+  -*,
+  performance-*,
+  bugprone-*,
+    -bugprone-narrowing-conversions,
+#  readability-*,
+#    -readability-magic-numbers,
+#    -readability-qualified-auto,
+#    -readability-braces-around-statements,
+#    -readability-uppercase-literal-suffix,
+#    -readability-avoid-const-params-in-decls,
+#    -readability-function-size,
+#    -readability-function-cognitive-complexity,
+#    -readability-container-size-empty
+#  clang-analyzer-*,
+#    -clang-analyzer-osx*,
+#  modernize-*,
+#    -modernize-use-trailing-return-type,
+
+WarningsAsErrors: ''
+#HeaderFilterRegex: 'graphtyper/'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+ - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+...

--- a/include/graphtyper/typer/sample_call.hpp
+++ b/include/graphtyper/typer/sample_call.hpp
@@ -45,7 +45,7 @@ public:
   std::pair<uint16_t, uint16_t> get_gt_call() const;
   uint8_t get_gq() const;
   uint8_t get_lowest_phred_not_with(uint16_t allele) const;
-  int8_t check_filter(long gq) const;
+  long check_filter(long gq) const;
 
 private:
   template <class Archive>

--- a/include/graphtyper/typer/vcf.hpp
+++ b/include/graphtyper/typer/vcf.hpp
@@ -35,7 +35,7 @@ class Vcf
   friend class cereal::access;
 
 public:
-  Vcf();
+  Vcf() = default;
   explicit Vcf(VCF_FILE_MODE _filemode, std::string const & filename);
   Vcf(Vcf const &) = delete;
   Vcf(Vcf &&) = delete;
@@ -83,7 +83,7 @@ public:
 
   // Adding data
   void add_hla_haplotypes(std::vector<Haplotype> & haplotypes,
-                          std::vector<std::unordered_map<uint32_t, uint32_t>> const & allele_hap_gts_ptr);
+                          std::vector<std::unordered_map<uint32_t, uint32_t>> const & all_hap_gts);
   void add_haplotype(Haplotype & haplotype, int32_t phase_set = -1);
 
   void add_haplotypes_for_extraction(std::vector<HaplotypeCall> const & hap_calls, bool const is_splitting_vars);

--- a/include/graphtyper/utilities/bgzf_stream.hpp
+++ b/include/graphtyper/utilities/bgzf_stream.hpp
@@ -55,14 +55,14 @@ inline BGZF_stream & BGZF_stream::operator<<(T const & x)
 
 inline void BGZF_stream::check_cache()
 {
-  if (static_cast<long>(ss.tellp()) > this->MAX_CACHE_SIZE)
+  if (static_cast<long>(ss.tellp()) > MAX_CACHE_SIZE)
     flush();
 }
 
 inline void BGZF_stream::flush()
 {
   // Write stringstream to BGZF file
-  if (!fp)
+  if (fp == nullptr)
   {
     std::cout << ss.str(); // Write uncompressed to stdout
   }
@@ -85,33 +85,29 @@ inline void BGZF_stream::flush()
 
 inline int BGZF_stream::write(void const * data, std::size_t length)
 {
-  if (!fp)
+  if (fp == nullptr)
   {
     std::cout << std::string(reinterpret_cast<const char *>(data), length);
     return length;
   }
-  else
-  {
-    return bgzf_write(fp, data, length);
-  }
+
+  return bgzf_write(fp, data, length);
 }
 
 inline int BGZF_stream::write(std::string const & str)
 {
-  if (!fp)
+  if (fp == nullptr)
   {
     std::cout << str;
     return str.size();
   }
-  else
-  {
-    return bgzf_write(fp, str.data(), str.size());
-  }
+
+  return bgzf_write(fp, str.data(), str.size());
 }
 
 inline void BGZF_stream::open(std::string const & _filename, std::string const & _filemode, long const _n_threads)
 {
-  if (fp)
+  if (fp != nullptr)
     close();
 
   if (_filename.size() > 0 && _filename != "-")
@@ -130,14 +126,14 @@ inline void BGZF_stream::open(std::string const & _filename, std::string const &
 
 inline bool BGZF_stream::is_open() const
 {
-  return fp;
+  return fp != nullptr;
 }
 
 inline void BGZF_stream::close()
 {
   flush();
 
-  if (fp)
+  if (fp != nullptr)
   {
     int ret = bgzf_close(fp);
 

--- a/src/typer/sample_call.cpp
+++ b/src/typer/sample_call.cpp
@@ -155,7 +155,7 @@ uint8_t SampleCall::get_lowest_phred_not_with(uint16_t allele) const
   return min_phred;
 }
 
-int8_t SampleCall::check_filter(long gq) const
+long SampleCall::check_filter(long gq) const
 {
   if (filter < 0)
   {

--- a/src/utilities/genotype.cpp
+++ b/src/utilities/genotype.cpp
@@ -74,8 +74,16 @@ std::vector<std::string> run_bamshrink(std::vector<std::string> const & sams,
     ss << tmp << "/bams/" << basename << ".bam";
     std::string path_out = ss.str();
     output_paths.push_back(path_out);
-    bamshrink_station
-      .add_work(bamshrink, bs_region.chr, bs_region.begin, bs_region.end, sam, sam_index, path_out, avg_cov, ref_fn);
+
+    bamshrink_station.add_work(bamshrink, // function name
+                               bs_region.chr,
+                               bs_region.begin,
+                               bs_region.end,
+                               sam,
+                               sam_index,
+                               path_out,
+                               avg_cov,
+                               ref_fn);
   }
 
   // Process the last sam on the main thread
@@ -92,7 +100,7 @@ std::vector<std::string> run_bamshrink(std::vector<std::string> const & sams,
     output_paths.push_back(path_out);
 
     bamshrink_station.add_to_thread(Options::const_instance()->threads - 1,
-                                    bamshrink,
+                                    bamshrink, // function name
                                     bs_region.chr,
                                     bs_region.begin,
                                     bs_region.end,
@@ -371,11 +379,11 @@ void genotype(std::string ref_path,
 
   if (copts.no_bamshrink)
   {
-    shrinked_sams = std::move(sams);
+    shrinked_sams = sams;
   }
   else
   {
-    print_log(log_severity::info, "Running bamShrink, which copies read data to tempory disk.");
+    print_log(log_severity::info, "Running bamShrink, which copies read data to temporary disk.");
     std::string bamshrink_ref_path;
 
     if (copts.force_use_input_ref_for_cram_reading)
@@ -665,7 +673,7 @@ void genotype(std::string ref_path,
   if (!copts.no_cleanup)
   {
     print_log(log_severity::info, "Cleaning up temporary files.");
-    remove_file_tree(tmp.c_str());
+    remove_file_tree(tmp);
   }
   else
   {
@@ -689,13 +697,13 @@ void genotype_regions(std::string const & ref_path,
                       std::vector<double> const & avg_cov_by_readlen,
                       bool const is_copy_reference)
 {
-  auto & opts = *(gyper::Options::instance());
   long const NUM_SAMPLES = sams.size();
 
   // parameter adjustment based on cohort size
   // default aln: 4 and 0.21, dis:0.30 and 8, ext: 9 and 2
   if (NUM_SAMPLES >= 4)
   {
+    auto & opts = *(gyper::Options::instance());
     // default aln: 5 and 0.23, dis:0.30 and 9, ext: 15 and 2
     ++opts.genotype_aln_min_support;
     ++opts.genotype_dis_min_support;

--- a/src/utilities/genotype_camou.cpp
+++ b/src/utilities/genotype_camou.cpp
@@ -118,7 +118,7 @@ void genotype_camou(std::string const & interval_fn,
 
   if (Options::const_instance()->no_bamshrink)
   {
-    shrinked_sams = std::move(sams);
+    shrinked_sams = sams;
   }
   else
   {

--- a/src/utilities/hts_reader.cpp
+++ b/src/utilities/hts_reader.cpp
@@ -47,13 +47,13 @@ void HtsReader::open(std::string const & path, std::string const & region, std::
           std::exit(1);
         }
 
-        std::size_t pos_id_ends = line_it.find("\t", pos_id + 1);
+        std::size_t pos_id_ends = line_it.find('\t', pos_id + 1);
 
         // Check if this is the last field
         if (pos_id_ends == std::string::npos)
           pos_id_ends = line_it.size();
 
-        std::size_t pos_samp_ends = line_it.find("\t", pos_samp + 1);
+        std::size_t pos_samp_ends = line_it.find('\t', pos_samp + 1);
 
         // Check if this is the last field
         if (pos_samp_ends == std::string::npos)

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -44,13 +44,13 @@ void get_sample_name_from_bam_header(std::string const & hts_filename,
         std::exit(1);
       }
 
-      std::size_t pos_id_ends = line_it.find("\t", pos_id + 1);
+      std::size_t pos_id_ends = line_it.find('\t', pos_id + 1);
 
       // Check if this is the last field
       if (pos_id_ends == std::string::npos)
         pos_id_ends = line_it.size();
 
-      std::size_t pos_samp_ends = line_it.find("\t", pos_samp + 1);
+      std::size_t pos_samp_ends = line_it.find('\t', pos_samp + 1);
 
       // Check if this is the last field
       if (pos_samp_ends == std::string::npos)

--- a/src/utilities/system.cpp
+++ b/src/utilities/system.cpp
@@ -66,7 +66,7 @@ std::string current_sec()
   char buf[32];
   time_structure = *localtime(&now);
   strftime(buf, sizeof(buf), "%y%m%d_%H%M%S", &time_structure);
-  std::string const sec(buf);
+  std::string sec(buf);
   return sec;
 }
 


### PR DESCRIPTION
Adds a Clang tidy config (`.clang-tidy`) in project root. PR also includes several fixes for a few of the current tidy warnings as a start (a ton of warnings still remain). A long term goal would be to fix all of those warnings and add a workflow check (similar to "check_format" with clang-format).