### PR TITLE
HLA most common 4digit alleles

### DIFF
--- a/include/graphtyper/typer/event.hpp
+++ b/include/graphtyper/typer/event.hpp
@@ -21,8 +21,9 @@ struct BaseCount
   int32_t deleted{0};
   int32_t unknown{0};
 
-  long get_depth_without_deleted() const;
-  long get_depth_with_deleted() const;
+  long get_depth_without_deleted() const; // does not include unknown
+  long get_depth_with_deleted() const;    // does not include unknown
+  long get_total_qualsum() const;         // only includes unique bases (A,C,G,T)
   std::string to_string() const;
 
   void add_base(char seq, char qual);

--- a/include/graphtyper/typer/variant.hpp
+++ b/include/graphtyper/typer/variant.hpp
@@ -39,9 +39,9 @@ public:
   Variant & operator=(Variant && o) noexcept;
   ~Variant() = default;
 
-  Variant(Genotype const & gt);
+  explicit Variant(Genotype const & gt);
   // Variant(std::vector<Genotype> const & gts, std::vector<uint16_t> const & hap_calls);
-  Variant(VariantCandidate const & var_candidate) noexcept;
+  explicit Variant(VariantCandidate const & var_candidate) noexcept;
 
   /******************
    * CLASS MODIFERS *

--- a/include/graphtyper/utilities/genotype_hla.hpp
+++ b/include/graphtyper/utilities/genotype_hla.hpp
@@ -7,7 +7,7 @@
 
 namespace gyper
 {
-void genotype_hla_regions(std::string ref_path,
+void genotype_hla_regions(std::string const & ref_path,
                           std::string const & hla_vcf,
                           std::string const & interval_fn,
                           std::vector<std::string> const & sams,

--- a/include/graphtyper/utilities/string.hpp
+++ b/include/graphtyper/utilities/string.hpp
@@ -110,7 +110,7 @@ inline int64_t stoi64(std::string_view str)
 
 // Returns an iterator to the nth occurence of an element (char). Expects n>=1.
 template <typename Tit>
-inline Tit find_nth_element(Tit begin, Tit end, char const element, int n)
+inline Tit find_nth_occurence(Tit begin, Tit end, char const element, int n)
 {
   assert(n >= 1);
   int count{0};

--- a/include/graphtyper/utilities/string.hpp
+++ b/include/graphtyper/utilities/string.hpp
@@ -108,4 +108,13 @@ inline int64_t stoi64(std::string_view str)
 }
 #endif
 
+// Returns an iterator to the nth occurence of an element (char). Expects n>=1.
+template <typename Tit>
+inline Tit find_nth_element(Tit begin, Tit end, char const element, int n)
+{
+  assert(n >= 1);
+  int count{0};
+  return std::find_if(begin, end, [&count, element, n](char x) { return x == element && ++count == n; });
+}
+
 } // namespace gyper

--- a/src/typer/event.cpp
+++ b/src/typer/event.cpp
@@ -46,6 +46,11 @@ long BaseCount::get_depth_with_deleted() const
   return acgt[0] + acgt[1] + acgt[2] + acgt[3] + deleted;
 }
 
+long BaseCount::get_total_qualsum() const
+{
+  return acgt_qualsum[0] + acgt_qualsum[1] + acgt_qualsum[2] + acgt_qualsum[3];
+}
+
 std::string BaseCount::to_string() const
 {
   std::ostringstream ss;


### PR DESCRIPTION
Improves 4-digit HLA calling in large populations.

When genotyping HLA alleles the output is limited to 100 different HLA alleles (due to downstream limitations). For large populations (5000+ individuals) this limit is often reached in 4-digit (2 field) calling in a few of the HLA genes (HLA-A, HLA-B, HLA-C, HLA-DRB1). With these changes the most common 4-digit HLA alleles are found in the population and called. Less common alleles are grouped together, i.e. `HLA-DRB1*04:XX` denoting all rare 4-digit alleles with the `HLA-DRB1*04` 2-digit allele.